### PR TITLE
fix Tensor.numpy()[0] to float(Tensor) to adapt 0D

### DIFF
--- a/04-sports_what/4.2-semantic_attribute/4.2.1-image_recognition/lcnetv2/lcnet_main.py
+++ b/04-sports_what/4.2-semantic_attribute/4.2.1-image_recognition/lcnetv2/lcnet_main.py
@@ -77,7 +77,7 @@ class LCNet_main():
                 optimizer.step()
 
 
-                self.log_writer.add_scalar(tag='train/loss', step=i, value=loss.numpy()[0])
+                self.log_writer.add_scalar(tag='train/loss', step=i, value=float(loss))
 
 
                 if i%100 == 3:


### PR DESCRIPTION
有些Tensor正确的语义为0D Tensor，其shape为[]，当前使用了shape为[1]替代，也就是向量Tensor：

在升级为0D后，Tensor.numpy()[0] 的写法不再使用，将其改变为 float(Tensor) 的写法，兼容升级前后。